### PR TITLE
[CRP-754] Define Internal Library for Protocol Constants and Roles

### DIFF
--- a/contracts/utils/Constants.sol
+++ b/contracts/utils/Constants.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.18;
+
+library Constants {
+
+    bytes32 constant internal POOL_STORAGE_READER = keccak256("POOL_STORAGE_READER");
+    bytes32 constant internal POOL_STORAGE_WRITER = keccak256("POOL_STORAGE_WRITER");
+    bytes32 constant internal DEPLOYER = keccak256("DEPLOYER");
+    bytes32 constant internal ADMIN = keccak256("ADMIN");
+    bytes32 constant internal LENDER = keccak256("LENDER");
+    bytes32 constant internal BORROWER = keccak256("BORROWER");
+    
+}


### PR DESCRIPTION
Create an internal library for defining protocol constants.

Define roles as keccak256 bytes32 values for the following:

```
POOL_STORAGE_READER

POOL_STORAGE_WRITER

DEPLOYER

ADMIN

LENDER

BORROWER
```