### PR TITLE
fix: trim newlines from lendingPoolParams

### DIFF
--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -28,6 +28,8 @@ export function getNumber(maxLength: number): number {
 export async function processLendingPoolParams(ethers: any, factory: PoolFactory, lendingPoolParams: string, network: string) {
     const signers = await ethers.getSigners();
 
+    lendingPoolParams = lendingPoolParams.trim();
+
     const tx = await signers[0].sendTransaction({
         to: factory.address,
         data: lendingPoolParams


### PR DESCRIPTION
One some machines the encoded lendignPoolParams get prefixed with new lines, adding this line removes them.