### PR TITLE
TF-1, HAL-5, HAL-8

### DIFF
--- a/contracts/pool/PoolTransfers.sol
+++ b/contracts/pool/PoolTransfers.sol
@@ -54,7 +54,6 @@ library PoolTransfers {
     // Remember to declare the event used in the function
     event PlatformTokensReceivedFromOldPool(address indexed lender, uint8 indexed trancheId, uint256 platformTokens);
 
-    // need to clarify the logic here
     // Only the principal
     function executeRollover(
         LendingPool lendingPool,
@@ -88,7 +87,6 @@ library PoolTransfers {
                     uint256 lenderRollOver = lenderPrincipal;
 
                     // only roll the lender if their deposit won't let them go over maxFundingCapacity
-                    // FIXME: I thought that as much of the lender's principal as possible should be rolled over and the rest returned to the lender
                     uint256 vaultMax = vault0.maxFundingCapacity();
                     if (lenderPrincipal + vault0.totalAssets() > vaultMax) {
                         // transfer the difference back to the lender
@@ -100,8 +98,7 @@ library PoolTransfers {
                     if (settings.platformTokens) {
                         // ask deadpool to move platform token into this new contract
                         for (uint8 trancheId; trancheId < tranchesCount; trancheId++) {
-                            // FIXME: transfer appropriate amount of platform tokens to the new pool
-                            // _transferPlatformTokensToNewPool(deadPool, lender, trancheId, lendingPool);
+                            // transfer appropriate amount of platform tokens to the new pool
                             uint256 platformTokens = deadpool.lenderStakedTokensByTranche(lender, trancheId);
                             uint256 rolloverPlatformTokens = (platformTokens * lenderPrincipal) / lenderRollOver;
                             _transferPlatformTokensToNewPool(

--- a/contracts/pool/PoolTransfers.sol
+++ b/contracts/pool/PoolTransfers.sol
@@ -16,13 +16,18 @@ library PoolTransfers {
         uint256 platformTokens
     );
 
-    function _transferAllPlatformTokensToNewPool(
+    // handle transfer of appropriate number of platform tokens from deadpool to new pool
+    function _transferPlatformTokensToNewPool(
         LendingPool deadPool,
         address lender,
         uint8 trancheId,
-        LendingPool lendingPool
+        LendingPool lendingPool,
+        uint256 platformTokens
     ) internal {
-        (, uint256 platformTokens, , ) = deadPool.s_trancheRewardables(trancheId, lender);
+        (, uint256 totalPlatformTokens, , ) = deadPool.s_trancheRewardables(trancheId, lender);
+        require(platformTokens <= totalPlatformTokens, "platform tokens exceed total");
+
+        // Is warning necessary?
         if (platformTokens == 0) {
             emit WarningLenderHasNoPlatformTokensStaked(lender, trancheId, platformTokens);
         }
@@ -49,6 +54,8 @@ library PoolTransfers {
     // Remember to declare the event used in the function
     event PlatformTokensReceivedFromOldPool(address indexed lender, uint8 indexed trancheId, uint256 platformTokens);
 
+    // need to clarify the logic here
+    // Only the principal
     function executeRollover(
         LendingPool lendingPool,
         address deadLendingPoolAddr,
@@ -72,28 +79,43 @@ library PoolTransfers {
                 continue;
             }
 
-            if (settings.platformTokens) {
-                // ask deadpool to move platform token into this new contract
-                for (uint8 trancheId; trancheId < tranchesCount; trancheId++) {
-                    _transferAllPlatformTokensToNewPool(deadpool, lender, trancheId, lendingPool);
-                }
-            }
-
             if (settings.rewards) {}
 
             if (settings.principal) {
                 for (uint8 trancheId; trancheId < tranchesCount; trancheId++) {
                     TrancheVault vault0 = TrancheVault(lendingPool.trancheVaultAddresses(trancheId));
                     uint256 lenderPrincipal = deadpool.lenderStakedTokensByTranche(lender, trancheId);
+                    uint256 lenderRollOver = lenderPrincipal;
 
                     // only roll the lender if their deposit won't let them go over maxFundingCapacity
+                    // FIXME: I thought that as much of the lender's principal as possible should be rolled over and the rest returned to the lender
                     uint256 vaultMax = vault0.maxFundingCapacity();
-                    if (lenderPrincipal + vault0.totalAssets() <= vaultMax) {
-                        rolledAssets += lenderPrincipal;
-                        vault0.transferShares(lender, deadTrancheAddrs[trancheId], lenderPrincipal);
+                    if (lenderPrincipal + vault0.totalAssets() > vaultMax) {
+                        // transfer the difference back to the lender
+                        uint256 excess = lenderPrincipal + vault0.totalAssets() - vaultMax;
+                        lenderRollOver -= excess;
+                    }
+                    rolledAssets += lenderRollOver;
+                    vault0.transferShares(lender, deadTrancheAddrs[trancheId], lenderRollOver);
+                    if (settings.platformTokens) {
+                        // ask deadpool to move platform token into this new contract
+                        for (uint8 trancheId; trancheId < tranchesCount; trancheId++) {
+                            // FIXME: transfer appropriate amount of platform tokens to the new pool
+                            // _transferPlatformTokensToNewPool(deadPool, lender, trancheId, lendingPool);
+                            uint256 platformTokens = deadpool.lenderStakedTokensByTranche(lender, trancheId);
+                            uint256 rolloverPlatformTokens = (platformTokens * lenderPrincipal) / lenderRollOver;
+                            _transferPlatformTokensToNewPool(
+                                deadpool,
+                                lender,
+                                trancheId,
+                                lendingPool,
+                                rolloverPlatformTokens
+                            );
+                        }
                     }
                 }
             }
+
             deadpool.poolDisableRollOver(lender);
         }
 


### PR DESCRIPTION
TF-1, HAL-5, HAL-8
- Handle scenario where partial rollover should be handled
- Prevent "over boost" scenario where excess platform tokens are rolled over without sufficient principal. 

Handles rollover of principal maintaining user's existing boost ratio. 